### PR TITLE
Ignoring local IPs to allow users to access their modems/routers

### DIFF
--- a/traktor.sh
+++ b/traktor.sh
@@ -33,6 +33,7 @@ sudo service polipo restart
 gsettings set org.gnome.system.proxy mode 'manual'
 gsettings set org.gnome.system.proxy.http host 127.0.0.1
 gsettings set org.gnome.system.proxy.http port 8123
+gsettings set org.gnome.system.proxy ignore-hosts "['localhost', '127.0.0.0/8', '::1', '192.168.0.0/16', '10.0.0.0/8', '172.16.0.0/12']"
 
 # Install Finish
 echo "Install Finished successfully…"


### PR DESCRIPTION
Few people were not able to access their modem/router settings on were confused. They did not know that they should disable proxy in the browsers or bypass local private IPs.

I suggest adding private IP ranges to proxy-bypass list in gnome settings.

I have double checked the syntax with GNOME IRC and @ehsanmaders (I do not have gnome)