### PR TITLE
Fixing tor.service starting problem on ArchLinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Do NOT expect anonymity using this method. Polipo is an http proxy and can leak 
     wget https://github.com/ubuntu-ir/traktor/archive/master.zip -O traktor.zip
     unzip traktor.zip && cd traktor-master
     ./traktor.sh
-
+## Install from AUR (ArchLinux only)
+    yaourt -S traktor
 
 ## Remote install
 type in bash:

--- a/traktor.sh
+++ b/traktor.sh
@@ -3,12 +3,12 @@
 # License : GPLv3+
 
 #Checking if the distro is debianbase / archbase  and running the correct script
-if [ "pacman -Q" ];then
+if pacman -Q &> /dev/null ;then
  ./traktor_arch.sh
 #    echo "arch"
-elif [ "apt list --installed"  ];then
+elif apt list --installed &> /dev/null ;then
    ./traktor_debian.sh
 #    echo "debian"
 else
     echo "Your distro is neither archbase nor debianbase So, The script is not going to work in your distro."
-fi
+fi  

--- a/traktor_arch.sh
+++ b/traktor_arch.sh
@@ -10,7 +10,7 @@ sudo pacman -S	tor obfsproxy polipo dnscrypt-proxy
 
 
 # Write Bridge
-sudo wget https://AmirrezaFiroozi.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
+sudo wget https://ubuntu-ir.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
 
 # Make tor log directory 
 sudo systemctl start tor 1>/dev/null 2>&1

--- a/traktor_arch.sh
+++ b/traktor_arch.sh
@@ -5,12 +5,12 @@ echo -e "Traktor v1.3\nTor will be automatically installed and configured…\n\n
 
 # Install Packages
 sudo pacman -Sy 1>/dev/null 2>&1
-#yaourt -S  tor-browser-en-ir
+yaourt -S  tor-browser-en-ir
 sudo pacman -S	tor obfsproxy polipo dnscrypt-proxy  
 
 
 # Write Bridge
-sudo wget https://ubuntu-ir.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
+sudo wget https://AmirrezaFiroozi.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
 
 # Make tor log directory 
 sudo systemctl start tor 1>/dev/null 2>&1
@@ -47,7 +47,7 @@ then
 	gsettings set org.gnome.system.proxy ignore-hosts "['localhost', '127.0.0.0/8', '::1', '192.168.0.0/16', '10.0.0.0/8', '172.16.0.0/12']"
 fi
 # Install Finish
-echo "Install Finished successfully…"
+echo -e "\nInstall Finished successfully…"
 sudo systemctl start tor 1>/dev/null 2>&1
 sudo systemctl enable tor 1>/dev/null 2>&1
 # Wait for tor to establish connection
@@ -61,11 +61,23 @@ while [ $bootstraped == 'n' ]; do
 		sleep 1
 	fi
 done
-echo -e "\nDo you want to install tor-browser too? [y/N]"
+#The following lines are commented because they were supposed to run in debian base distros
+# Add tor repos
+#echo "deb tor+http://deb.torproject.org/torproject.org stable main" | sudo tee /etc/apt/sources.list.d/tor.list > /dev/null
 
-read -n 1 SELECT
-if [ "$SELECT" = "Y" -o "$SELECT" = "y" ]
-then
-yaourt -S tor-browser-en-ir
-fi
+# Fetching Tor signing key and adding it to the keyring
+#gpg --keyserver keys.gnupg.net --recv 886DDD89
+#gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+
+# update tor from main repo
+#sudo apt-get update > /dev/null
+#sudo apt install -y \
+#	tor \
+#	obfs4proxy
+
+# Fix Apparmor problem
+#sudo sed -i '27s/PUx/ix/' /etc/apparmor.d/abstractions/tor
+#sudo apparmor_parser -r -v /etc/apparmor.d/system_tor
+
+# update finished
 echo "Congratulations!!! Your computer is using Tor. may run tor-browser-en-ir now."

--- a/traktor_arch.sh
+++ b/traktor_arch.sh
@@ -8,6 +8,13 @@ sudo pacman -Sy 1>/dev/null 2>&1
 yaourt -S  tor-browser-en-ir
 sudo pacman -S	tor obfsproxy polipo dnscrypt-proxy  
 
+#configuring dnscrypt-proxy
+sudo wget https://AmirrezaFiroozi.github.io/traktor/dnscrypt-proxy.service -O /usr/lib/systemd/system/dnscrypt-proxy.service > /dev/null
+sudo systemctl daemon-reload
+echo "nameserver 127.0.0.1" | sudo tee /etc/resolv.conf >/dev/null
+sudo chattr +i /etc/resolv.conf
+sudo systemctl enable dnscrypt-proxy.service
+sudo systemctl start dnscrypt-proxy
 
 # Write Bridge
 sudo wget https://ubuntu-ir.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null

--- a/traktor_arch.sh
+++ b/traktor_arch.sh
@@ -5,7 +5,7 @@ echo -e "Traktor v1.3\nTor will be automatically installed and configured…\n\n
 
 # Install Packages
 sudo pacman -Sy 1>/dev/null 2>&1
-yaourt -S  tor-browser-en-ir
+#yaourt -S  tor-browser-en-ir
 sudo pacman -S	tor obfsproxy polipo dnscrypt-proxy  
 
 # Make tor log directory 
@@ -43,7 +43,7 @@ then
 	gsettings set org.gnome.system.proxy ignore-hosts "['localhost', '127.0.0.0/8', '::1', '192.168.0.0/16', '10.0.0.0/8', '172.16.0.0/12']"
 fi
 # Install Finish
-echo -e "\nInstall Finished successfully…"
+echo "Install Finished successfully…"
 sudo systemctl start tor 1>/dev/null 2>&1
 sudo systemctl enable tor 1>/dev/null 2>&1
 # Wait for tor to establish connection
@@ -57,23 +57,11 @@ while [ $bootstraped == 'n' ]; do
 		sleep 1
 	fi
 done
-#The following lines are commented because they were supposed to run in debian base distros
-# Add tor repos
-#echo "deb tor+http://deb.torproject.org/torproject.org stable main" | sudo tee /etc/apt/sources.list.d/tor.list > /dev/null
+echo -e "\nDo you want to install tor-browser too? [y/N]"
 
-# Fetching Tor signing key and adding it to the keyring
-#gpg --keyserver keys.gnupg.net --recv 886DDD89
-#gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
-
-# update tor from main repo
-#sudo apt-get update > /dev/null
-#sudo apt install -y \
-#	tor \
-#	obfs4proxy
-
-# Fix Apparmor problem
-#sudo sed -i '27s/PUx/ix/' /etc/apparmor.d/abstractions/tor
-#sudo apparmor_parser -r -v /etc/apparmor.d/system_tor
-
-# update finished
+read -n 1 SELECT
+if [ "$SELECT" = "Y" -o "$SELECT" = "y" ]
+then
+yaourt -S tor-browser-en-ir
+fi
 echo "Congratulations!!! Your computer is using Tor. may run tor-browser-en-ir now."

--- a/traktor_arch.sh
+++ b/traktor_arch.sh
@@ -8,13 +8,17 @@ sudo pacman -Sy 1>/dev/null 2>&1
 #yaourt -S  tor-browser-en-ir
 sudo pacman -S	tor obfsproxy polipo dnscrypt-proxy  
 
+
+# Write Bridge
+sudo wget https://ubuntu-ir.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
+
 # Make tor log directory 
+sudo systemctl start tor 1>/dev/null 2>&1
+sudo systemctl stop tor 1>/dev/null 2>&1
+
 sudo mkdir /var/log/tor/
 sudo chown tor:tor /var/log/tor/
 sudo chmod g+w /var/log/tor/
-# Write Bridge
-sudo wget https://AmirrezaFiroozi.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
-
 # Fix Apparmor problem
 #sudo sed -i '27s/PUx/ix/' /etc/apparmor.d/abstractions/tor
 #sudo apparmor_parser -r -v /etc/apparmor.d/system_tor


### PR DESCRIPTION
Tor couldn`t be started duo to not having write permisson on /var/log/tor/log
This will fix it.
Getting bridges from ubuntu-ir to reassure users from bridges` source