### PR TITLE
Adding dnscrypt-proxy.service file

### DIFF
--- a/dnscrypt-proxy.service
+++ b/dnscrypt-proxy.service
@@ -16,6 +16,4 @@ NonBlocking=true
 # Fill in the resolver name with one from dnscrypt-resolvers.csv file
 # It is also recommended to create a dedicated system user, for example _dnscrypt
 # Additional features, such as ephemeral keys and plugins, can be enabled here as well
-ExecStart=/usr/bin/dnscrypt-proxy \
-          --resolver-name=<resolver name> \
-          --user=<user name to run the service as>
+ExecStart=/usr/bin/dnscrypt-proxy -R cisco

--- a/dnscrypt-proxy.service
+++ b/dnscrypt-proxy.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=DNSCrypt client proxy
+Documentation=man:dnscrypt-proxy(8)
+Requires=dnscrypt-proxy.socket
+After=network.target
+Before=nss-lookup.target
+
+[Install]
+Also=dnscrypt-proxy.socket
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+NonBlocking=true
+
+# Fill in the resolver name with one from dnscrypt-resolvers.csv file
+# It is also recommended to create a dedicated system user, for example _dnscrypt
+# Additional features, such as ephemeral keys and plugins, can be enabled here as well
+ExecStart=/usr/bin/dnscrypt-proxy \
+          --resolver-name=<resolver name> \
+          --user=<user name to run the service as>


### PR DESCRIPTION
Some users may avoid getting dnscrypt-proxy.service file from different sources than ubuntu-ir .
The first step is to add this file into gh-pages branch . After that we will be able to edit traktor_arch.sh so that it gets files from ubuntu-ir