### PR TITLE
Backing up the existing torrc to avoid future problems

### DIFF
--- a/traktor_arch.sh
+++ b/traktor_arch.sh
@@ -16,6 +16,10 @@ sudo chattr +i /etc/resolv.conf
 sudo systemctl enable dnscrypt-proxy.service
 sudo systemctl start dnscrypt-proxy
 
+if [ -f "/etc/tor/torrc" ]; then
+    echo "Backing up the old torrc to '/etc/tor/torrc.traktor-backup'..."
+    sudo cp /etc/tor/torrc /etc/tor/torrc.traktor-backup
+fi
 # Write Bridge
 sudo wget https://ubuntu-ir.github.io/traktor/torrcV3 -O /etc/tor/torrc > /dev/null
 

--- a/traktor_debian.sh
+++ b/traktor_debian.sh
@@ -13,6 +13,11 @@ sudo apt install -y \
 	torbrowser-launcher \
 	apt-transport-tor
 
+if [ -f "/etc/tor/torrc" ]; then
+    echo "Backing up the old torrc to '/etc/tor/torrc.traktor-backup'..."
+    sudo cp /etc/tor/torrc /etc/tor/torrc.traktor-backup
+fi
+
 # Write Bridge
 sudo wget https://ubuntu-ir.github.io/traktor/torrc -O /etc/tor/torrc > /dev/null
 


### PR DESCRIPTION
### It's important to backup user's original `torrc` (if exists) to avoid losing any data.